### PR TITLE
Only use username part of JID on login()

### DIFF
--- a/src/org/yaxim/androidclient/service/SmackableImp.java
+++ b/src/org/yaxim/androidclient/service/SmackableImp.java
@@ -285,7 +285,7 @@ public class SmackableImp implements Smackable {
 					AccountManager am = new AccountManager(mXMPPConnection);
 					am.createAccount(mConfig.userName, mConfig.password);
 				}
-				mXMPPConnection.login(mConfig.userName, mConfig.password,
+				mXMPPConnection.login(StringUtils.parseName(mConfig.userName), mConfig.password,
 						mConfig.ressource);
 			}
 			setStatusFromConfig();


### PR DESCRIPTION
Use only the username part of a JID on Connection.login(), or else some
servers (e.g. openfire) will throw a "SASL authentication failed using
mechanism DIGEST-MD5" exception on login.
