### PR TITLE
Set minimum priority for service notifications

### DIFF
--- a/src/org/yaxim/androidclient/service/XMPPService.java
+++ b/src/org/yaxim/androidclient/service/XMPPService.java
@@ -319,7 +319,7 @@ public class XMPPService extends GenericService {
 		}
 		Notification n = new Notification(R.drawable.ic_offline, null,
 				System.currentTimeMillis());
-		n.flags = Notification.FLAG_ONGOING_EVENT | Notification.FLAG_NO_CLEAR;
+		n.flags = Notification.FLAG_ONGOING_EVENT | Notification.FLAG_NO_CLEAR | Notification.PRIORITY_MIN;
 
 		Intent notificationIntent = new Intent(this, MainWindow.class);
 		notificationIntent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);


### PR DESCRIPTION
This prevents them from spamming my smartwatch with notifications whenever yaxim loses connectivity. As these are not presented to the user anywhere but in the persistent notification, I don't think this should be a problem?
