### PR TITLE
Only alert once on status notifications

### DIFF
--- a/src/org/yaxim/androidclient/service/XMPPService.java
+++ b/src/org/yaxim/androidclient/service/XMPPService.java
@@ -319,7 +319,7 @@ public class XMPPService extends GenericService {
 		}
 		Notification n = new Notification(R.drawable.ic_offline, null,
 				System.currentTimeMillis());
-		n.flags = Notification.FLAG_ONGOING_EVENT | Notification.FLAG_NO_CLEAR;
+		n.flags = Notification.FLAG_ONGOING_EVENT | Notification.FLAG_NO_CLEAR | Notification.FLAG_ONLY_ALERT_ONCE;
 
 		Intent notificationIntent = new Intent(this, MainWindow.class);
 		notificationIntent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);


### PR DESCRIPTION
(Because my previous pull request was really dumb.)

This helps quite a bit - I still don't really want to see these on my watch, but it prevents them from spamming it and pushing the notifications I really care about out of the queue. I haven't yet found a better way to do this.

As these notifications aren't meant to alert anyway, it doesn't seem like this has any effect on non-smartwatch users. Any objections?
